### PR TITLE
[WIP] Finish 0.1 pup golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM python:2.7
+FROM ubuntu:16.04
 
 RUN apt-get update -qq
-RUN apt-get -y install vim
+RUN apt-get -y install \
+  build-essential \
+  git \
+  python \
+  python-apt \
+  python-pip \
+  vim
 
 RUN pip install --upgrade pip
 RUN pip install "ansible>=2.0,<3.0"
@@ -11,6 +17,10 @@ RUN mkdir /sheepdoge-test
 WORKDIR /sheepdoge-test
 
 ADD tasks ./tasks
+ADD vars ./vars
 ADD tests/* ./
+
+# Delete any defaults setup in the ~/.bashrc because they can mess with testing
+RUN rm ~/.bashrc && touch ~/.bashrc
 
 RUN chmod u+x test.sh

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,5 @@ build:
 test: build
 	docker run sheepdoge/pup-golang /bin/bash -c "./test.sh"
 
+interactive: build
+	docker run -it sheepdoge/pup-golang /bin/bash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
-# pup-mattjmcnaughton-dotfiles
+# pup-golang
 
-[sheepdoge](https://github.com/mattjmcnaughton/sheepdoge) pup for managing my
-personal dotfiles.
+[sheepdoge](https://github.com/mattjmcnaughton/sheepdoge) pup for managing
+golang.
+
+## Variables
+
+- `pup_golang_vars_dotfile`: The dotfile in which to configure GOPATH.
+- `pup_golang_vars_gopath`: The GOPATH.
+- `pup_golang_vars_go_bins`: A list of go binaries to install.
+- `pup_golang_vars_go_deleted_bins`: A list of binaries to ensure are not
+  installed.
+
+## Requirements
+
+If you do not already have `go` installed, you will need either `homebrew` or
+`python-apt` (depending on your OS).

--- a/tasks/go_env.yml
+++ b/tasks/go_env.yml
@@ -1,13 +1,18 @@
 ---
-- name: Set the GOPATH in the dotfile.
+- name: ensure GOPATH directory exists
+  file:
+    path: "{{ gopath }}"
+    state: directory
+
+- name: set the GOPATH in the dotfile
   lineinfile:
     path: "{{ dotfile }}"
     state: present
     line: "export GOPATH={{ gopath }}"
 
-- name: Add GOPATH/bin to PATH
+- name: add GOPATH/bin to PATH
   lineinfile:
-    path: "{{ dotffile }}"
+    path: "{{ dotfile }}"
     state: present
-    line: "export PATH=\$GOPATH/bin:\$PATH"
+    line: "[[ \":$PATH:\" != *\":$GOPATH/bin:\"* ]] && PATH=\"$GOPATH/bin:$PATH\" || true"
     insertafter: "^export GOPATH"

--- a/tasks/go_packages.yml
+++ b/tasks/go_packages.yml
@@ -1,8 +1,12 @@
 ---
-- name: Install go packages.
-  shell: "GOPATH={{ gopath }} go get -u {{ item }}"
+- name: install go packages
+  shell: ". ~/.bashrc && go get -u {{ item }}"
+  args:
+    executable: /bin/bash
   with_items: "{{ go_bins }}"
 
-- name: Uninstall go packages.
-  shell: "GOPATH={{ gopath }} go clean -i {{ item }}"
-  with_teims: "{{ go_deleted_bins }}"
+- name: uninstall go packages
+  shell: ". ~/.bashrc && go clean -i {{ item }}"
+  args:
+    executable: /bin/bash
+  with_items: "{{ go_deleted_bins }}"

--- a/tasks/install_go-Darwin.yml
+++ b/tasks/install_go-Darwin.yml
@@ -1,5 +1,5 @@
 ---
-# @TODO(mattjmcnaughton) Determine a way to control version.
-- homebrew:
+- name: install golang with homebrew
+  homebrew:
     name: go
     state: present

--- a/tasks/install_go-Debian.yml
+++ b/tasks/install_go-Debian.yml
@@ -1,5 +1,19 @@
 ---
-# @TODO(mattjmcnaughton) Determine a way to control version.
-apt:
-  name: golang-go
-  state: present
+# @TODO(mattjmcnaughton) Determine if I want to dynamically control the version.
+- name: download the go tar
+  get_url:
+    url: https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz
+    dest: /tmp/go1.9.linux-amd64.tar.gz
+    checksum: "sha256:d70eadefce8e160638a9a6db97f7192d8463069ab33138893ad3bf31b0650a79"
+
+- name: extract the tarball
+  unarchive:
+    src: /tmp/go1.9.linux-amd64.tar.gz
+    dest: /usr/local
+    copy: no
+
+- name: ensure go binary discoverable in PATH
+  lineinfile:
+    path: "{{ dotfile }}"
+    state: present
+    line: "[[ \":$PATH:\" != *\":/usr/local/go/bin:\"* ]] && PATH=\"/usr/local/go/bin:$PATH\" || true"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,18 @@
 ---
-- include: install_go-Debian.yml
-  when: ansible_os_family == 'Debian'
-- include: install_go-Darwin.yml
-  when: ansible_os_family == 'Darwin'
-- include: go_env.yml
-- include: go_packages.yml
+- name: determine if go installed
+  command: which go
+  register: go_is_installed
+  failed_when: go_is_installed.rc > 1
+  changed_when: no
+
+- name: install go on debian
+  include_tasks: install_go-Debian.yml
+  when: ansible_os_family == 'Debian' and go_is_installed.rc > 0
+- name: install go on Darwin
+  include_tasks: install_go-Darwin.yml
+  when: ansible_os_family == 'Darwin' and go_is_installed.rc > 0
+
+- name: configure go environment variables
+  include_tasks: go_env.yml
+- name: install go packages
+  include_tasks: go_packages.yml

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -3,4 +3,4 @@
   connection: local
 
   tasks:
-    - include: tasks/main.yml
+    - include_tasks: tasks/main.yml

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -3,15 +3,39 @@
 set -e
 
 test::check_syntax() {
-  ansible-playbook playbook.yml --syntax-check
+  ansible-playbook playbook.yml -i 'localhost' -e '{"dotfile": "~/.bashrc", "gopath": "/go", "go_bins": ["golang.org/x/tools/...", "github.com/golang/lint/golint"], "go_deleted_bins": []}' --syntax-check
 }
 
 test::run_ansible() {
-  ansible-playbook playbook.yml
+  ansible-playbook playbook.yml -i 'localhost' -e '{"dotfile": "~/.bashrc", "gopath": "/go", "go_bins": ["golang.org/x/tools/...", "github.com/golang/lint/golint"], "go_deleted_bins": []}'
 }
 
 test::assert_output() {
-  echo 'TODO'
+  . ~/.bashrc
+
+  if ! which go >/dev/null; then
+    echo 'go is not installed'
+    exit 1
+  fi
+
+  if ! echo $PATH | grep -q "$GOPATH/bin"; then
+    echo "$GOPATH/bin not included in $PATH"
+    exit 1
+  fi
+
+  if ! which golint >/dev/null; then
+    echo "golint is not installed"
+    exit 1
+  fi
+
+  # Assert when we source ~/.bashrc again, we only write $GOPATH/bin to $PATH
+  # once
+  . ~/.bashrc
+
+  if [ ":$PATH:" == "*:$GOPATH/bin:*:$GOPATH/bin:*" ]; then
+    echo "$GOPATH/bin written to $PATH to often"
+    exit 1
+  fi
 }
 
 test::check_syntax


### PR DESCRIPTION
This commit contains the following code to get to 0.1 for pup-golang.
We make the following changes:

- Expand the variables the user can define (i.e. `go_bins`, `gopath`,
  etc.)
- Download go binary directly on Debian, to ensure we get a recent
  version (16.04 includes go 1.3 by default, which is much too old).
- Ensure path entries only occur once.
- Write unit tests.
- Switch from using a python2.7 base docker image to Ubuntu 16.04 to
  resolve some sys.path issues with `python-apt`.